### PR TITLE
Fix check on golang 1.12

### DIFF
--- a/sops/PKGBUILD
+++ b/sops/PKGBUILD
@@ -28,7 +28,7 @@ build() {
 
 check() {
   cd src/go.mozilla.org/sops
-  env GOPATH="${srcdir}" go test
+  env GO111MODULE=on GOPATH="${srcdir}" go test
 }
 
 package() {


### PR DESCRIPTION
Build is success, but check is failed on golang 1.12.x. I send PR with fix it. Please add or apply this PR.