### PR TITLE
updpkg: sops 3.5.0-2

### DIFF
--- a/sops/.SRCINFO
+++ b/sops/.SRCINFO
@@ -1,13 +1,14 @@
 pkgbase = sops
 	pkgdesc = Editor of encrypted files that supports YAML, JSON and BINARY formats
 	pkgver = 3.5.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/mozilla/sops
 	arch = i686
 	arch = x86_64
 	arch = aarch64
 	license = MPL2
 	makedepends = go
+	depends = glibc
 	source = sops-3.5.0.tar.gz::https://github.com/mozilla/sops/archive/v3.5.0.tar.gz
 	sha256sums = a9c257dc5ddaab736dce08b8c5b1f00e6ca1e3171909b6d7385689044ebe759b
 

--- a/sops/PKGBUILD
+++ b/sops/PKGBUILD
@@ -3,36 +3,30 @@
 
 pkgname=sops
 pkgver=3.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Editor of encrypted files that supports YAML, JSON and BINARY formats'
 arch=('i686' 'x86_64' 'aarch64')
 url='https://github.com/mozilla/sops'
 license=('MPL2')
+depends=('glibc')
 makedepends=('go')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
 sha256sums=('a9c257dc5ddaab736dce08b8c5b1f00e6ca1e3171909b6d7385689044ebe759b')
 
-prepare() {
-  mkdir -p src/go.mozilla.org
-  mv ${pkgname}-${pkgver} src/go.mozilla.org/sops
-}
-
 build() {
-  cd src/go.mozilla.org/sops
-  env GO111MODULE=on GOPATH="${srcdir}" go build \
-    -asmflags all="-trimpath=${PWD}" \
-    -gcflags all="-trimpath=${PWD}" \
-    -ldflags all="-extldflags=${LDFLAGS}" \
-    ./cmd/sops
+  cd "${pkgname}-${pkgver}"
+  export CGO_LDFLAGS="$LDFLAGS"
+  export GOFLAGS='-buildmode=pie -modcacherw -trimpath'
+  go build -o "$pkgname" ./cmd/sops/
 }
 
 check() {
-  cd src/go.mozilla.org/sops
-  env GO111MODULE=on GOPATH="${srcdir}" go test
+  cd "${pkgname}-${pkgver}"
+  go test
 }
 
 package() {
-  cd src/go.mozilla.org/sops
+  cd "${pkgname}-${pkgver}"
   install -Dm755 sops "${pkgdir}/usr/bin/${pkgname}"
   install -Dm644 README.rst "${pkgdir}/usr/share/doc/${pkgname}/README.rst"
 }


### PR DESCRIPTION
Drop `prepare()`.
Remove `GO111MODULE` env.
Add `glibc` to depends.
Pass buildflags via CGO_LDFLAGS and GOFLAGS. (now with RELRO & PIE)

Related: https://lists.archlinux.org/pipermail/arch-dev-public/2020-March/029898.html

I have no strong opinion on setting `GOPATH` inside `$srcdir`. I understand that many prefer not to have dependencies downloaded to their `HOME`. Having duplicate dependencies across several AUR packages or redownloading them on each build sucks as well.

So if you prefer to keep the `GOPATH` override, I'll readd.